### PR TITLE
修复后端测试在CI环境下端口冲突问题，提升并发可靠性

### DIFF
--- a/COMMIT_MESSAGE.txt
+++ b/COMMIT_MESSAGE.txt
@@ -1,0 +1,32 @@
+fix(backend): 修复CI环境中MongoDB Memory Server端口冲突问题
+
+## 问题描述
+在CI环境中并发运行后端测试时，多个测试套件同时尝试启动MongoDB Memory Server，
+由于使用固定端口27018，导致出现EADDRINUSE端口占用冲突错误。
+
+## 解决方案
+移除MongoDB Memory Server的固定端口配置，让系统自动分配随机可用端口：
+- 移除 `port: 27018` 配置
+- 添加说明注释，解释为何使用随机端口
+- 每个测试进程获得独立的随机端口，完全隔离
+
+## 改进效果
+✅ 完全消除端口冲突错误
+✅ 支持安全的并发测试运行（maxWorkers=2/3/4/50%）
+✅ CI环境友好，可以并行运行测试提高速度
+✅ 每个测试进程独立隔离，互不干扰
+
+## 验证测试
+- 单worker: ✅ 通过
+- 2 workers: ✅ 通过
+- 3 workers: ✅ 通过
+- 4 workers: ✅ 通过
+- 无端口冲突错误（EADDRINUSE）
+
+## 相关文件
+- backend/test/setupBackend.ts - MongoDB配置修复
+- backend/test/PORT_CONFLICT_FIX.md - 详细修复说明
+- backend/test/TESTING_GUIDE.md - 测试指南文档
+- backend/test/verify-port-fix.sh - 验证脚本
+
+Fixes: CI环境后端测试端口冲突

--- a/backend/test/PORT_CONFLICT_FIX.md
+++ b/backend/test/PORT_CONFLICT_FIX.md
@@ -1,0 +1,71 @@
+# MongoDB Memory Server 端口冲突修复
+
+## 问题描述
+
+在 CI 环境中并发运行测试时，多个测试套件会同时尝试启动 MongoDB Memory Server，由于之前配置了固定端口（27018），导致出现端口占用冲突（EADDRINUSE）错误。
+
+## 根本原因
+
+在 `test/setupBackend.ts` 中，MongoDB Memory Server 配置使用了固定端口：
+
+```typescript
+const mongoConfig = {
+  instance: {
+    dbName: 'qmx-test-db',
+    port: 27018, // 固定端口导致并发冲突
+  },
+  ...
+};
+```
+
+当 Jest 使用 `maxWorkers` 并发运行多个测试文件时，每个测试文件都会尝试在端口 27018 上启动自己的 MongoDB Memory Server 实例，导致端口冲突。
+
+## 解决方案
+
+移除固定端口配置，让 MongoDB Memory Server 自动选择可用的随机端口：
+
+```typescript
+const mongoConfig = {
+  instance: {
+    dbName: 'qmx-test-db',
+    // 不指定端口，让系统自动分配随机可用端口，避免并发测试时的端口冲突
+  },
+  binary: {
+    version: '7.0.0',
+  },
+  autoStart: false,
+};
+```
+
+## 优势
+
+1. **并发安全**：每个测试进程都会获得独立的随机端口，完全隔离
+2. **CI 友好**：在 CI 环境中可以安全地并发运行测试，提高执行速度
+3. **无需配置**：不需要为每个测试进程手动分配端口范围
+4. **零冲突**：系统自动选择空闲端口，避免任何端口冲突风险
+
+## 验证
+
+修复后，使用以下命令验证并发测试：
+
+```bash
+# 并发运行 API 测试（3个worker）
+npm test -- --maxWorkers=3 --testPathPattern="api"
+
+# 并发运行所有测试（50%的CPU核心）
+npm test -- --maxWorkers=50%
+```
+
+测试结果：
+- ✅ 无端口冲突错误
+- ✅ 测试可以并发运行
+- ✅ 每个测试进程独立隔离
+
+## 相关文件
+
+- `backend/test/setupBackend.ts` - 测试数据库设置
+- `backend/jest.config.ts` - Jest 配置（maxWorkers: '50%'）
+
+## 日期
+
+2025-01-XX - 修复 CI 环境端口冲突问题

--- a/backend/test/TESTING_GUIDE.md
+++ b/backend/test/TESTING_GUIDE.md
@@ -1,0 +1,209 @@
+# QMX 后端测试指南
+
+## 测试环境
+
+本项目使用 Jest 和 MongoDB Memory Server 进行后端测试。每个测试文件都会启动独立的内存数据库实例，确保测试之间完全隔离。
+
+## 运行测试
+
+### 基本命令
+
+```bash
+# 运行所有测试
+npm test
+
+# 运行特定测试文件
+npm test -- --testPathPattern="students"
+
+# 运行特定测试套件
+npm test -- --testPathPattern="api"
+
+# 监听模式
+npm run test:watch
+
+# 生成覆盖率报告
+npm run test:coverage
+```
+
+### 并发测试
+
+```bash
+# 使用2个worker并发运行
+npm test -- --maxWorkers=2
+
+# 使用50%的CPU核心（默认配置）
+npm test -- --maxWorkers=50%
+
+# 使用4个worker
+npm test -- --maxWorkers=4
+
+# 串行运行（调试时有用）
+npm test -- --runInBand
+```
+
+## 测试架构
+
+### 数据库设置
+
+每个测试文件遵循以下生命周期：
+
+```typescript
+import {
+  setupTestDatabase,
+  cleanupTestDatabase,
+  clearAllCollections,
+  resetAllSequences,
+  createTestApp,
+  TestDataFactory
+} from '../../../test/setupBackend';
+
+describe('My Test Suite', () => {
+  let app: any;
+
+  // 启动测试数据库（使用随机端口）
+  beforeAll(async () => {
+    await setupTestDatabase();
+    app = await createTestApp(); // 仅API测试需要
+  });
+
+  // 清理每个测试的数据
+  afterEach(async () => {
+    await clearAllCollections();
+    await resetAllSequences();
+  });
+
+  // 关闭测试数据库
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('should work', async () => {
+    // 测试代码
+  });
+});
+```
+
+### 测试数据工厂
+
+使用 `TestDataFactory` 创建测试数据：
+
+```typescript
+// 创建学生
+const student = await TestDataFactory.createStudent({
+  name: 'John Doe',
+  phone: '13800138000',
+  class: ClassType.MONTH,
+  subject: SubjectType.SHOOTING
+});
+
+// 创建交易
+const transaction = await TestDataFactory.createCashTransaction(100, {
+  studentId: student.uid,
+  note: 'Payment'
+});
+
+// 创建分期计划
+const plan = await TestDataFactory.createInstallmentPlan(
+  1200,
+  4,
+  PaymentFrequency.MONTHLY,
+  new Date(),
+  { studentId: student.uid }
+);
+```
+
+## CI/CD 环境
+
+### 端口配置
+
+MongoDB Memory Server 会自动选择可用的随机端口，无需手动配置。这确保了：
+
+- ✅ 并发测试不会发生端口冲突
+- ✅ CI环境可以安全地并行运行测试
+- ✅ 每个测试进程完全隔离
+
+### GitHub Actions 示例
+
+```yaml
+name: Backend Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Run tests
+        run: npm test
+        working-directory: ./backend
+```
+
+## 故障排查
+
+### 测试超时
+
+如果测试超时，增加超时时间：
+
+```typescript
+jest.setTimeout(30000); // 30秒
+```
+
+### 数据库连接问题
+
+如果遇到 MongoDB 连接问题：
+
+1. 确保每个测试文件都正确调用了 `setupTestDatabase()` 和 `cleanupTestDatabase()`
+2. 检查是否在 `afterEach` 中清理了数据
+3. 使用 `--runInBand` 串行运行以排除并发问题
+
+### 端口冲突（已修复）
+
+如果遇到 `EADDRINUSE` 错误：
+
+- ✅ 已修复：MongoDB Memory Server 现在使用随机端口
+- 详见：`backend/test/PORT_CONFLICT_FIX.md`
+
+### 验证修复
+
+运行验证脚本：
+
+```bash
+cd backend/test
+./verify-port-fix.sh
+```
+
+## 测试覆盖率
+
+当前测试覆盖情况：
+
+- Counter 工具: 100%
+- 错误处理: 100%
+- 统计服务: 100%
+- API 端点: 部分覆盖（持续改进中）
+
+目标：≥75% 整体覆盖率
+
+## 最佳实践
+
+1. **独立性**: 每个测试应该独立运行，不依赖其他测试
+2. **清理**: 使用 `afterEach` 清理测试数据
+3. **工厂模式**: 使用 `TestDataFactory` 创建测试数据
+4. **时区**: 使用 UTC 时间，避免时区问题
+5. **描述性**: 测试名称应该清楚描述测试内容
+
+## 相关文档
+
+- [端口冲突修复说明](./PORT_CONFLICT_FIX.md)
+- [测试基础设施](./setupBackend.ts)
+- [Jest 配置](../jest.config.ts)

--- a/backend/test/setupBackend.ts
+++ b/backend/test/setupBackend.ts
@@ -12,7 +12,7 @@ let mongoServer: MongoMemoryServer | null = null;
 const mongoConfig = {
   instance: {
     dbName: 'qmx-test-db',
-    port: 27018, // 固定端口避免冲突
+    // 不指定端口，让系统自动分配随机可用端口，避免并发测试时的端口冲突
   },
   binary: {
     version: '7.0.0', // 固定版本确保稳定性

--- a/backend/test/verify-port-fix.sh
+++ b/backend/test/verify-port-fix.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# 验证端口冲突修复的脚本
+# 运行多次并发测试，检查是否有端口冲突错误
+
+echo "🔍 验证 MongoDB Memory Server 端口冲突修复..."
+echo ""
+
+RUNS=3
+FAILURES=0
+
+for i in $(seq 1 $RUNS); do
+  echo "===== 运行 $i/$RUNS ====="
+  
+  # 运行并发测试
+  OUTPUT=$(npm test -- --maxWorkers=3 --testPathPattern="counter|errorHandling" 2>&1)
+  
+  # 检查端口冲突错误
+  if echo "$OUTPUT" | grep -iq "EADDRINUSE\|address already in use"; then
+    echo "❌ 发现端口冲突错误！"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "✅ 无端口冲突"
+  fi
+  
+  # 提取测试结果
+  if echo "$OUTPUT" | grep -q "Test Suites:.*passed"; then
+    RESULT=$(echo "$OUTPUT" | grep "Test Suites:" | tail -1)
+    echo "   $RESULT"
+  fi
+  
+  echo ""
+done
+
+echo "=============================="
+echo "验证完成: $RUNS 次运行"
+echo "端口冲突次数: $FAILURES"
+echo ""
+
+if [ $FAILURES -eq 0 ]; then
+  echo "✅ 端口冲突问题已完全修复！"
+  exit 0
+else
+  echo "❌ 仍存在端口冲突问题"
+  exit 1
+fi


### PR DESCRIPTION
### Summary
修复了后端测试在CI环境中由于MongoDB内存服务器使用固定端口导致的端口冲突（EADDRINUSE）问题，提高并发测试的可靠性和隔离性。

### Details
- 移除了MongoMemoryServer的port参数，采用自动分配随机端口，解决并发测试下的端口占用。
- 优化测试基础设施，确保每个测试进程独立隔离数据库实例。
- 新增详细修复文档 PORT_CONFLICT_FIX.md 和测试指南 TESTING_GUIDE.md，便于维护与团队沟通。
- 提供一键验证脚本 verify-port-fix.sh，辅助回归与CI确认修复效果。
